### PR TITLE
Add support for disabled class.

### DIFF
--- a/addon/components/active-link.js
+++ b/addon/components/active-link.js
@@ -2,8 +2,16 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: 'li',
-  classNameBindings: ['active'],
+  disabled: false,
+  classNameBindings: ['active', 'disabled'],
   active: function() {
+
+    var disabled = this.get('disabled');
+
+    if (disabled) {
+      return false;
+    }
+
     return this.get('childViews').anyBy('active');
-  }.property('childViews.@each.active')
+  }.property('childViews.@each.active', 'disabled')
 });


### PR DESCRIPTION
Hi Alex,

Hope you're well!

Finding this add-on really useful. However, it would be great to add support for adding a `disabled` class. I've added it but I'm not fussy about the implementation if you need to play around with it!

It's useful for some of the Bootstrap components, where you can add a disabled class to links as the opposite of active.

Cheers,
Chris
