### PR TITLE
Fix issue #14: don’t require afterRender for views

### DIFF
--- a/addon/mixins/active-link.js
+++ b/addon/mixins/active-link.js
@@ -14,7 +14,7 @@ export default Ember.Mixin.create({
   }),
 
   buildChildLinkViews: Ember.on('didRender', function(){
-    Ember.run.schedule('afterRender', this, function(){
+    Ember.run.next(this, function(){
       let childLinkSelector = this.get('linkSelector');
       let childLinkElements = this.$(childLinkSelector);
 


### PR DESCRIPTION
##### Edit:

Instead of building child link views `afterRender`, build them some time after `render`
