### PR TITLE
Allow setting disabled attribute on active-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ There are several options available to adjust functionality:
 | linkSelector  | 'a.ember-view' | jQuery selector for child `{{link-to}}`'s                       |
 | activeClass   | _Computed_**   | Class name to apply when any child `{{link-to}}` is also active |
 | disabledClass | _Computed_**   | Class name to apply when ALL child `{{link-to}}`'s are disabled |
+| disable       | null           | Boolean: ignore children and apply the disabled class           |
 
 ** Default class names are pulled from the child `{{link-to}}`,
 which in turn defaults to 'active'. You can change it on either
@@ -99,6 +100,21 @@ even if child `{{link-to}}`'s are active/disabled.
 ```html
 <li>
     <a href="/" class="disabled">Index</a>
+</li>
+```
+
+The the parent element can be forcibly disabled
+by passing a boolean `true` for disabled.
+
+```hbs
+{{#active-link disabled=true}}
+  {{link-to "Index" "index"}}
+{{/active-link}}
+```
+
+```html
+<li class"disabled">
+    <a href="/" class="active">Index</a>
 </li>
 ```
 

--- a/addon/mixins/active-link.js
+++ b/addon/mixins/active-link.js
@@ -61,7 +61,7 @@ export default Ember.Mixin.create({
   }),
 
   _disabled: Ember.computed('allLinksDisabled', 'disabledClass', function(){
-    return (this.get('allLinksDisabled') ? this.get('disabledClass') : false);
+    return (this.get('disabled') || this.get('allLinksDisabled') ? this.get('disabledClass') : false);
   })
 
 });


### PR DESCRIPTION
I'm using a computed property to disable a child link. The computed property gets set asynchronously when the model loads. When that happens, I get the dreaded "You modified **\* twice in a single render" deprecation warning:

```
DEPRECATION: You modified (-join-classes "ember-view" (-normalize-class "_active" _active 
activeClass=undefined inactiveClass=undefined) (-normalize-class "_disabled" _disabled 
activeClass=undefined inactiveClass=undefined) (-normalize-class "_transitioningIn" _transitioningIn 
activeClass=undefined inactiveClass=undefined) (-normalize-class "_transitioningOut" _transitioningOut 
activeClass=undefined inactiveClass=undefined) (-normalize-class "disabled" disabled 
activeClass=undefined inactiveClass=undefined)) twice in a single render. This was unreliable in Ember 
1.x and will be removed in Ember 3.0 [deprecation id: ember-views.render-double-modify]
```

I believe this is occurring because the child link 'disabled' class gets applied, then ember-cli-active-link-wrapper kicks in and applies the 'disabled' class to the wrapper element. I could of course set `{{active-link disabledClass=false}}` to prevent this; however, I need the wrapper element to have the 'disabled' class applied so that it disables the bootstrap nav item.

This PR doesn't directly address the underlying issue of the double modification. All it does is allow for setting the disabled attribute on {{active-link}} itself rather than letting it be set dynamically based on the state of the children. Users can then manually disable the wrapper element.

For me, this fixes the double render issue because I can set my computed property directly on {{active-link}} so only one modification occurs during render. 
