### PR TITLE
Fix ember 2.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1-13
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/addon/mixins/active-link.js
+++ b/addon/mixins/active-link.js
@@ -17,9 +17,11 @@ export default Ember.Mixin.create({
     Ember.run.schedule('afterRender', this, function(){
       let childLinkSelector = this.get('linkSelector');
       let childLinkElements = this.$(childLinkSelector);
+      let applicationContainer = Ember.getOwner(this).application.__container__;
+      let viewRegistry = applicationContainer.lookup('-view-registry:main') || Ember.View.views;
 
-      let childLinkViews = childLinkElements.toArray().map(view =>
-        this._viewRegistry[view.id]
+      let childLinkViews = childLinkElements.toArray().map(
+        view => viewRegistry[view.id]
       );
 
       this.set('childLinkViews', Ember.A(childLinkViews));

--- a/addon/mixins/active-link.js
+++ b/addon/mixins/active-link.js
@@ -9,16 +9,18 @@ export default Ember.Mixin.create({
   classNameBindings: ['_active','_disabled','_transitioningIn','_transitioningOut'],
   linkSelector: 'a.ember-view',
 
-  initChildLinkViews: Ember.on('init', function(){
-    this.set('childLinkViews', Ember.A());
-  }),
+  init() {
+    this._super(...arguments);
 
-  buildChildLinkViews: Ember.on('didRender', function(){
-    Ember.run.schedule('afterRender', this, function(){
+    this.set('childLinkViews',  Ember.A([]));
+  },
+
+  buildChildLinkViews: Ember.on('didReceiveAttrs', function(){
+    Ember.run.scheduleOnce('afterRender', this, function(){
       let childLinkSelector = this.get('linkSelector');
       let childLinkElements = this.$(childLinkSelector);
       let applicationContainer = Ember.getOwner(this).application.__container__;
-      let viewRegistry = applicationContainer.lookup('-view-registry:main') || Ember.View.views;
+      let viewRegistry = applicationContainer.lookup('-view-registry:main');
 
       let childLinkViews = childLinkElements.toArray().map(
         view => viewRegistry[view.id]

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-active-link-wrapper",
   "dependencies": {
-    "ember": "~2.4.1",
+    "ember": "~2.3.0",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0"

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,17 +8,6 @@ module.exports = {
       }
     },
     {
-      name: 'ember-1-13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
-    },
-    {
       name: 'ember-release',
       bower: {
         dependencies: {


### PR DESCRIPTION
This should fix the addon for Ember 2.8 and now works with Glimmer 2 also. 

It's important to note that this will only support Ember 2.3+. 
