### PR TITLE
Fastboot fixes

### DIFF
--- a/addon/mixins/active-link.js
+++ b/addon/mixins/active-link.js
@@ -15,7 +15,7 @@ export default Ember.Mixin.create({
     this.set('childLinkViews',  Ember.A([]));
   },
 
-  buildChildLinkViews: Ember.on('didReceiveAttrs', function(){
+  buildChildLinkViews: Ember.on('didInsertElement', function(){
     Ember.run.scheduleOnce('afterRender', this, function(){
       let childLinkSelector = this.get('linkSelector');
       let childLinkElements = this.$(childLinkSelector);
@@ -55,7 +55,7 @@ export default Ember.Mixin.create({
   }),
 
   allLinksDisabled: Ember.computed('childLinkViews.@each.disabled', function(){
-    return this.get('childLinkViews').isEvery('disabled');
+    return !Ember.isEmpty(this.get('childLinkViews')) && this.get('childLinkViews').isEvery('disabled');
   }),
 
   disabledClass: Ember.computed('childLinkViews.@each.disabled', function(){


### PR DESCRIPTION
Switch `buildChildLinkViews` to use `didInsertElement` since it uses jQuery/ect (#19). 

Also adjusted the `allLinksDisabled` CP since it returns a bit of a false positive in cases where the component contains no child link views (such as in fastboot, since the link views array is not built in this case), as `isEvery()` returns true if the array is empty. In fastboot apps, this causes the server rendered page to have the disabled class applied to all `{{active-link}}`s until the app boots on the client.
